### PR TITLE
Update README for setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 For more details on GTM, please see http://datachemeng.com/generativetopographicmapping/.
 
 For more details on k3n error, please see http://datachemeng.com/k3nerror/ or https://www.sciencedirect.com/science/article/pii/S0169743918300698.
+
+
+### Install
+You can install this python module by executing the following command:
+
+```
+git clone https://github.com/hkaneko1985/gtm-generativetopographicmapping.git
+cd gtm-generativetopographicmapping/Python
+pip install -e .
+```


### PR DESCRIPTION
setup.py更新時につけるべきだった
`pip install -e .` でインストールできる旨をREADMEに加えます。